### PR TITLE
added settings for min length and when whitespace

### DIFF
--- a/Text Marker.sublime-settings
+++ b/Text Marker.sublime-settings
@@ -58,10 +58,22 @@
 		*/
 		"draw_outlined": false,
 
+		/* MIN LENGTH OF WORDS TO HIGHLIGHT
+			Use this in your user prefs to set the minimum length of selected text to
+			highlight.
+		*/
+		"min_length": 4,
+
 		/* HIGHLIGHT WORDS WHEN SELECTION IS EMPTY
 			Use this in your user prefs to make words highlight when the insertion point
 			is inside of them but they're not actually selected.
 		*/
-		"when_selection_is_empty": true
+		"when_selection_is_empty": true,
+
+		/* HIGHLIGHT WORDS WHEN SELECTION IS WHITESPACE
+			Use this in your user prefs to selected text highlight when the selection
+			is whitespace.
+		*/
+		"when_whitespace": true
 	}
 }


### PR DESCRIPTION
I really like having the ability to highlight matches to the word selected rather than just getting a border by default in sublime. However it's arguably not very nice getting this functionality with words of length 1-2 or even 3 and for whitespace and this is incredibly slow on files with 10k+ loc (which I often work with), so I had a tinker and added in settings for users to set these things themselves. 

I added `min_length` and `when_whitespace` settings, both seem to work perfectly fine, and then `text marker` is super fast still on files with 10k+ loc. 

Also fyi I have been unable to get the other functionality of text marker working because on my machine `alt + space` brings up whether to minimize/maximise/move/resize the window etc. and `alt + escape` cycles through the open windows in the active workspace. I'm running ubuntu 18.04LTS with gnome-session-flashback as the desktop environment. 

Also I've had trouble with having `when_selection_is_empty` being `true`. Sometimes the highlighting gets stuck and I can't clear it (recall I also can't do `alt + escape` on my machine), the only way to clear it is to save settings with `live` set to `false` then resave with it set to `true` again. I don't seem to have any trouble with the following though:

````
/*
	Text Marker user settings in here override the default
*/
{
	"user": {
		"live": true,
		"live_color": "yellow",
		"min_length": 4,
		"when_selection_is_empty": false,
		"when_whitespace": false
	}
}
````