### PR TITLE
added feature highlighting only the selection

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,4 +1,5 @@
 [
 	{ "keys": [ "alt+space" ], "command": "text_marker",  },
+	{ "keys": [ "alt+shift+space" ], "command": "text_marker_exact_selection",  },
 	{ "keys": [ "alt+escape" ], "command": "text_marker_clear" }
 ]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Simply use <kbd>Alt</kbd>+<kbd>Space</kbd> to mark selected text.
 
 - Being over a word or having some selection, press <kbd>Alt</kbd>+<kbd>Space</kbd> to mark all.
 
+- <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd> to mark only the selection.
+
 - <kbd>Alt</kbd>+<kbd>Escape</kbd> clears all marked text.
 
 - Each time you mark a word a different color will be used (colors are configurable in the settings)


### PR DESCRIPTION
currently, the plugin will expand to all words in the text by the selected character. 

I have added an enhancement to highlight only the selected characters.

The use case is that, when I want to highlight the characters searched by regular expression in the text for specific purpose (for example in SQL, the keyword `update`), the plugin will highlight all words `update`, including the word in comment or other syntax, which makes me confused.

I have zero experience on Python, please kindly advise. 😄 

![image](https://user-images.githubusercontent.com/10892928/145706639-ab429d99-6f58-4262-8b57-d70f2c6c8bb1.png)
